### PR TITLE
enter ganspace folder before trying to find requirements

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -3,9 +3,10 @@
 2. Install git, then clone respository: `git clone https://github.com/harskish/ganspace/`
 3. Create environment: `conda create -n ganspace python=3.7`
 4. Activate environment: `conda activate ganspace`
-5. Install dependencies: `conda env update -f environment.yml --prune`
-6. Setup submodules: `git submodule update --init --recursive`
-7. Run command `python -c "import nltk; nltk.download('wordnet')"`
+5. Go into ganspace folder: `cd ganspace`
+6. Install dependencies: `conda env update -f environment.yml --prune`
+7. Setup submodules: `git submodule update --init --recursive`
+8. Run command `python -c "import nltk; nltk.download('wordnet')"`
 
 ### Interactive viewer
 The interactive viewer (<i>interactive.py</i>) has the following dependencies:


### PR DESCRIPTION
I noticed that after I created the environment, I was still in the base folder (I never came into the newly cloned folder), so adding that step. This resolves the "not a git" errors some people are complaining about, for example #10 #16 #39