### PR TITLE
Add Open in Kaggle badge

### DIFF
--- a/notebooks/figure_teaser.ipynb
+++ b/notebooks/figure_teaser.ipynb
@@ -1,5 +1,12 @@
 {
  "cells": [
+   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://kaggle.com/kernels/welcome?src=https://github.com/harskish/ganspace/blob/master/notebooks/figure_teaser.ipynb\"><img align=\"left\" alt=\"Kaggle\" title=\"Open in Kaggle\" src=\"https://kaggle.com/static/images/open-in-kaggle.svg\"></a>"
+   ]
+  },
   {
    "cell_type": "code",
    "execution_count": null,


### PR DESCRIPTION
This is an example of what adding a Kaggle Badge (that allows for opening the .ipynb as a Kaggle Notebook as seen here https://www.kaggle.com/product-feedback/152480) would look like.

If it makes sense I can submit a further PR adding it to other notebooks in the repo.